### PR TITLE
Added MQTT publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets.h

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a file called "secrets.h" and set the following constants.  Note that "se
 * MQTT_BROKER - the hostname or IP address (e.g., `IPAddress(192, 168, 1, 1)`) of the MQTT broker.
 * TEMP_TOPIC - the name of the topic to publish temperature messages.
 * HUMIDITY_TOPIC - the name of the topic to publish humidity messages.
+* LOOP_DELAY - integer representing the delay in milliseconds at the end of loop().
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# MQTT Temperature and Humidity Sensor
+
+Arduino code for periodically publishing temperature and humidity measurements to an MQTT broker.
+
+## Hardware
+
+* Arduino-compatible board with WiFi connectivity. For this project, I used the [FeatherS3](https://esp32s3.com/feathers3.html) development board
+* [BME280](https://www.bosch-sensortec.com/products/environmental-sensors/humidity-sensors-bme280/) Temperature, Humidity, and Pressure Sensor. Adafruit offers a [breakout board](https://www.adafruit.com/product/2652) which easily connects to the STEMMA QT connector on the FeatherS3 board
+* [STEMMA QT cable](https://www.adafruit.com/product/4399)
+* Lithium Polymer Battery with JST connector
+
+## Libraries
+
+The following libraries should be added to the Arduino IDE using the library manager.
+
+* [Adafruit_BME280_Library](https://github.com/adafruit/Adafruit_BME280_Library)
+* [MQTT](https://github.com/256dpi/arduino-mqtt)
+* [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
+
+## Configuration
+
+Create a file called "secrets.h" and set the following constants.  Note that "secrets.h" is ignored in the .gitignore file to avoid accidentally checking it in.
+
+* WIFI_SSID - the SSID of the WiFi network to connect to.
+* WIFI_PASSWORD - the password for the WiFi network.
+* MQTT_CLIENT_ID - the client ID for connecting to the MQTT broker.
+* MQTT_BROKER - the hostname or IP address (e.g., `IPAddress(192, 168, 1, 1)`) of the MQTT broker.
+* TEMP_TOPIC - the name of the topic to publish temperature messages.
+* HUMIDITY_TOPIC - the name of the topic to publish humidity messages.
+
+## Example Output
+
+After opening the serial monitor, you should see something similar to the following if everything works as expected:
+
+```
+Initializing BME280 sensor...OK
+Connecting to Wi-Fi.....OK
+Connecting to MQTT broker...OK
+PUBLISH home/office/temperature - {"time":4043,"temperature":24.79000092} - OK
+PUBLISH home/office/humidity - {"time":4045,"humidity":33.27246094} - OK
+```
+## TODO  
+
+* [x] Reconnect to WiFi and MQTT on disconnect
+* [ ] Add username/password authentication for MQTT
+* [ ] Add TLS support for MQTT

--- a/mqtt-temp-sensor.ino
+++ b/mqtt-temp-sensor.ino
@@ -35,6 +35,8 @@ void setupWiFi() {
 }
 
 void setupMQTT() {
+  digitalWrite(LED_BUILTIN, HIGH);
+
   if(WiFi.status() != WL_CONNECTED) {
     setupWiFi();
   }
@@ -42,7 +44,7 @@ void setupMQTT() {
   client.begin(MQTT_BROKER, 1883, net);
   Serial.print("Connecting to MQTT broker...");
 
-  while (!client.connect(THINGNAME)) {
+  while (!client.connect(MQTT_CLIENT_ID)) {
     Serial.print(".");
     delay(100);
   }
@@ -52,12 +54,15 @@ void setupMQTT() {
     return;
   }
 
+  digitalWrite(LED_BUILTIN, LOW);
   Serial.println("OK");
 }
 
 void setup() {
   Serial.begin(9600);
   delay(1500); // extra time to allow host to connect
+
+  pinMode(LED_BUILTIN, OUTPUT);
   
   setupSensor();
 }

--- a/mqtt-temp-sensor.ino
+++ b/mqtt-temp-sensor.ino
@@ -101,5 +101,5 @@ void loop() {
   publishMeasurement(HUMIDITY_TOPIC, "humidity", humidity_event.relative_humidity);
 
   client.loop();
-  delay(1000);
+  delay(LOOP_DELAY);
 }

--- a/mqtt-temp-sensor.ino
+++ b/mqtt-temp-sensor.ino
@@ -1,37 +1,100 @@
 #include <Wire.h>
 #include <SPI.h>
 #include <Adafruit_BME280.h>
+#include <MQTTClient.h>
+#include <ArduinoJson.h>
+#include "WiFi.h"
+#include "secrets.h"
 
 Adafruit_BME280 bme; // use I2C interface
 Adafruit_Sensor *bme_temp = bme.getTemperatureSensor();
 Adafruit_Sensor *bme_humidity = bme.getHumiditySensor();
 
-void setup() {
-  Serial.begin(9600);
-  Serial.println(F("BME280 Sensor event test"));
+WiFiClient net = WiFiClient();
+MQTTClient client = MQTTClient(256);
 
+void setupSensor() {
+  Serial.print("Initializing BME280 sensor...");
   if (!bme.begin()) {
-    Serial.println(F("Could not find a valid BME280 sensor, check wiring!"));
+    Serial.println("failed");
     while (1) delay(10);
   }
+  Serial.println("OK");
+}
+
+void setupWiFi() {
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+  Serial.print("Connecting to Wi-Fi...");
+  while (WiFi.status() != WL_CONNECTED){
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("OK");
+}
+
+void setupMQTT() {
+  if(WiFi.status() != WL_CONNECTED) {
+    setupWiFi();
+  }
+
+  client.begin(MQTT_BROKER, 1883, net);
+  Serial.print("Connecting to MQTT broker...");
+
+  while (!client.connect(THINGNAME)) {
+    Serial.print(".");
+    delay(100);
+  }
+
+  if(!client.connected()){
+    Serial.println("fail");
+    return;
+  }
+
+  Serial.println("OK");
+}
+
+void setup() {
+  Serial.begin(9600);
+  delay(1500); // extra time to allow host to connect
   
-  bme_temp->printSensorDetails();
-  bme_humidity->printSensorDetails();
+  setupSensor();
+}
+
+void publishMeasurement(const char* topic, char* measurement, float val) {
+  StaticJsonDocument<200> doc;
+  doc["time"] = millis();
+  doc[measurement] = val;
+  char jsonBuffer[512];
+  serializeJson(doc, jsonBuffer); // print to client
+
+  Serial.print("PUBLISH ");
+  Serial.print(topic);
+  Serial.print(" - "); 
+  Serial.print(jsonBuffer);
+  Serial.print(" - ");
+
+  if(!client.publish(topic, jsonBuffer)) {
+    Serial.println("fail");
+    return;
+  };
+
+  Serial.println("OK");
 }
 
 void loop() {
+  if(!client.connected()) {
+    setupMQTT();
+  }
+
   sensors_event_t temp_event, humidity_event;
   bme_temp->getEvent(&temp_event);
   bme_humidity->getEvent(&humidity_event);
   
-  Serial.print(F("Temperature = "));
-  Serial.print(temp_event.temperature);
-  Serial.println(" *C");
+  publishMeasurement(TEMP_TOPIC, "temperature", temp_event.temperature);
+  publishMeasurement(HUMIDITY_TOPIC, "humidity", humidity_event.relative_humidity);
 
-  Serial.print(F("Humidity = "));
-  Serial.print(humidity_event.relative_humidity);
-  Serial.println(" %");
-
-  Serial.println();
+  client.loop();
   delay(1000);
 }


### PR DESCRIPTION
This PR builds upon a demo that prints temperature and humidity measurements to the serial port.  This handles connecting to the WiFi network and the MQTT broker, including reconnecting as needed. There are separate topics for temperature and humidity. The built-in LED is also used to indicate that the board is attempting to connect to MQTT. 